### PR TITLE
Moved watershed to own file and finished implementing

### DIFF
--- a/src/dataset/augmentation.py
+++ b/src/dataset/augmentation.py
@@ -135,10 +135,7 @@ class ZoomBPS(object):
         else:
             return img_resize
         
-class ApplyWatershed(object):
-    """Apply watershed to images"""
-    def call(self, image: np.ndarray) -> Tuple:
-        pass
+
 
 
 def main():

--- a/src/models/watershed.py
+++ b/src/models/watershed.py
@@ -1,0 +1,54 @@
+import cv2
+import numpy as np
+import torch
+from typing import Any, Tuple
+import torchvision
+import random
+
+class Watershed(object):
+    def get_mask(self, image: np.ndarray):
+        """Apply watershed to images"""
+        avg_intensity = self.getAverage(image)
+
+        bw_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)  
+        
+        ret, thresh = cv2.threshold(bw_image,avg_intensity + 2,255, cv2.THRESH_BINARY)
+
+        kernel = np.ones((3,3),np.uint8)
+
+        # sure background area
+        sure_bg = cv2.dilate(thresh,kernel,iterations=2)
+
+        # Finding sure foreground area
+        dist_transform = cv2.distanceTransform(thresh,cv2.DIST_L2,5)
+        ret, sure_fg = cv2.threshold(dist_transform,0.05*dist_transform.max(),255,0)
+
+        # Finding unknown region
+        sure_fg = np.uint8(sure_fg)
+        unknown = cv2.subtract(sure_bg,sure_fg)
+
+        # Marker labelling
+        ret, markers = cv2.connectedComponents(sure_fg)
+
+        # Add one to all labels so that sure background is not 0, but 1
+        markers = markers+1
+
+        # Now, mark the region of unknown with zero
+        markers[unknown==255] = 0
+
+        markers = cv2.watershed(image,markers)
+        image[markers == -1] = [255,0,0]
+
+        #cv2.imwrite(f'test_output\{i}_watershed.png', markers)
+        return markers
+
+    def getAverage(self, image: np.ndarray) -> int:
+        sum = 0
+        num_elements = 0
+        
+        for value in np.nditer(image):
+            if value > 0: 
+                sum += value
+                num_elements += 1
+
+        return int(sum / num_elements)


### PR DESCRIPTION
#### Description
Removed ApplyWatershed class from augmentations.py and added a new file called watershed.py under src/models. In the watershed.py class added a function called getAverages. This function finds the average intensity of non-black pixels. We ignore the black pixels as those are typically the background and we want it so that it doesn't skew our average intensity distribution. This is used to find the threshold in the get_mask function.  With the threshold, we convert the image to a black-and-white image. Then with the black-and-white image, we find the foreground, background, and unknown region. We use this information to construct the mask per standard watershed technique.

closes #8  #5 

#### How to use
- [ ] Get images using the bps_dataset make sure it returns a numpy array and not a tensor, NORMALIZE TRANSFORMATION IS REQUIRED
- [ ] Numpy array should also be uint8, the bps_dataset class should already handle that, but in case of running it without our bps_dataset class
- [ ] Returns a 32bit single channel image of the mask (the mask is the outline of the focci)

#### How has this been tested
- [x] This has mainly been tested in our test-05 branch and we just moved the changes over.


#### Checklist
- [x] My code conforms with the style guidelines of this project
- [x] I have self-reviewed my code
- [x]  I have had a group partner review my code.
- [x] No warnings have been generated
- [x] Everything works as intended